### PR TITLE
Maintain new lines in long commands and and new lines between commands in dockerfile

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -42,7 +42,7 @@ func WriteDockerfile(builder *strings.Builder, node *parser.Node, useOriginal bo
 				splitsTrimmed = append(splitsTrimmed, strings.TrimSpace(split))
 			}
 		}
-		s := strings.Join(splitsTrimmed, " \\ \n\t")
+		s := strings.Join(splitsTrimmed, " \\\n    ")
 		builder.WriteString(s)
 	}
 	for _, child := range node.Children {

--- a/docker.go
+++ b/docker.go
@@ -35,11 +35,19 @@ func WriteDockerfile(builder *strings.Builder, node *parser.Node, useOriginal bo
 	if useOriginal {
 		builder.WriteString(node.Original)
 	} else {
-		builder.WriteString(node.Value)
+		splits := strings.Split(node.Value, "  ")
+		splitsTrimmed := []string{}
+		for _, split := range splits {
+			if split != "" {
+				splitsTrimmed = append(splitsTrimmed, strings.TrimSpace(split))
+			}
+		}
+		s := strings.Join(splitsTrimmed, " \\ \n\t")
+		builder.WriteString(s)
 	}
 	for _, child := range node.Children {
 		WriteDockerfile(builder, child, useOriginal)
-		builder.WriteString("\n")
+		builder.WriteString("\n\n")
 	}
 
 	if node.Next != nil {


### PR DESCRIPTION
The written dockerfile will now look like 
```dockerfile
FROM golang:1.22-bookworm@sha256:6d71b7c3f884e7b9552bffa852d938315ecca843dcc75a86ee7000567da0923d as builder

RUN apt-get update && dpkg --add-architecture arm64 && apt-get update && \ 
	apt-get install --no-install-recommends -y curl:arm64=7.88.1-10+deb12u5 wget:arm64=1.21.3-1+b1 \ 
	&& rm -rf /var/lib/apt/lists/* \ 
	&& apt-get clean

```

instead of 
```dockerfile
FROM golang:1.22-bookworm@sha256:6d71b7c3f884e7b9552bffa852d938315ecca843dcc75a86ee7000567da0923d as builder
RUN apt-get update && dpkg --add-architecture arm64 && apt-get update &&      apt-get install --no-install-recommends -y curl:arm64=7.88.1-10+deb12u5 wget:arm64=1.21.3-1+b1     && rm -rf /var/lib/apt/lists/*     && apt-get clean

```