### PR TITLE
feat: preserve original formatting, maintaining things like comments in the generated dockerfile

### DIFF
--- a/cmd/anchor/root.go
+++ b/cmd/anchor/root.go
@@ -78,12 +78,25 @@ var rootCmd = &cobra.Command{
 		}
 		appendArch := len(options.Architectures) > 1
 
+		content, err := os.Open(options.InputFile)
+		if err != nil {
+			return err
+		}
+		defer content.Close()
+		lines := []string{}
+		scanner := bufio.NewScanner(content)
+		for scanner.Scan() {
+			lines = append(lines, scanner.Text())
+		}
+
+		if err := scanner.Err(); err != nil {
+			return err
+		}
 		for _, architecture := range options.Architectures {
 			content, err := os.Open(options.InputFile)
 			if err != nil {
 				return err
 			}
-
 			defer content.Close()
 			result, err := parser.Parse(content)
 			if err != nil {
@@ -91,7 +104,6 @@ var rootCmd = &cobra.Command{
 			}
 
 			node := result.AST
-			anchor.PrintNode(node)
 
 			color.Cyan("Anchoring to architecture: %s\n", architecture)
 			image := ""
@@ -101,7 +113,7 @@ var rootCmd = &cobra.Command{
 			}
 
 			var builder strings.Builder
-			anchor.WriteDockerfile(&builder, node, true)
+			anchor.WriteDockerfile(&builder, node, true, 0, lines)
 			outputName := options.OutputFile
 			if appendArch {
 				outputName = fmt.Sprintf("%s.%s", outputName, architecture)

--- a/docker.go
+++ b/docker.go
@@ -28,7 +28,19 @@ func attachDockerSha(node *parser.Node) (string, error) {
 	return node.Value, nil
 }
 
-func WriteDockerfile(builder *strings.Builder, node *parser.Node, useOriginal bool) {
+func WriteDockerfile(builder *strings.Builder, node *parser.Node, useOriginal bool, currentLine int, lines []string) int {
+	// this allows us to maintain things like comments and newlines in the original Dockerfile
+	if currentLine != 0 && node.StartLine != 0 && currentLine < node.StartLine {
+		for i := currentLine + 1; i < node.StartLine; i++ {
+			builder.WriteString(lines[i-1])
+			builder.WriteString("\n")
+		}
+	}
+	if currentLine == 0 {
+		currentLine = 1
+	} else if node.EndLine != 0 {
+		currentLine = node.EndLine
+	}
 	if node.Value == "FROM" || node.Value == "RUN" {
 		useOriginal = false
 	}
@@ -46,24 +58,15 @@ func WriteDockerfile(builder *strings.Builder, node *parser.Node, useOriginal bo
 		builder.WriteString(s)
 	}
 	for _, child := range node.Children {
-		WriteDockerfile(builder, child, useOriginal)
-		builder.WriteString("\n\n")
+		currentLine = WriteDockerfile(builder, child, useOriginal, currentLine, lines)
+		builder.WriteString("\n")
 	}
 
 	if node.Next != nil {
 		builder.WriteString(" ")
-		WriteDockerfile(builder, node.Next, useOriginal)
+		currentLine = WriteDockerfile(builder, node.Next, useOriginal, currentLine, lines)
 	}
-}
-
-func PrintNode(node *parser.Node) {
-	for _, child := range node.Children {
-		PrintNode(child)
-	}
-
-	if node.Next != nil {
-		PrintNode(node.Next)
-	}
+	return currentLine
 }
 
 func ParseNode(node *parser.Node, architecture string, image *string) error {


### PR DESCRIPTION
Will now attempt to fill in the non-anchored parts with the original lines in the template dockerfile. For example, for the songstitch dockerfile, the generated one looks like:

```dockerfile
FROM node:21-alpine@sha256:db8772d9f5796ac4e8c47508038c413ea1478da010568a2e48672f19a8b80cd2 AS node-builder

WORKDIR /app/ui 
COPY ui ./  
RUN npm install && npm run build

FROM golang:1.22-bookworm@sha256:6d71b7c3f884e7b9552bffa852d938315ecca843dcc75a86ee7000567da0923d AS builder

WORKDIR /app 

COPY go.mod go.sum Makefile ./    
COPY vendor ./vendor  
COPY cmd ./cmd  
COPY internal ./internal  
COPY assets ./assets  
COPY --from=node-builder /app/public ./public  

SHELL ["/bin/bash", "-o", "pipefail", "-c"]    

# Minify Assets
# hadolint ignore=DL3008
RUN apt-get update \
    && dpkg --add-architecture arm64 && apt-get update && \
    apt-get install -y --no-install-recommends \
    minify:arm64=2.12.4-2 \
    libwebp-dev:arm64=1.2.4-0.2+deb12u1 \
    && find ./public -type f \( \
    -name "*.html" \
    -o -name '*.js' \
    -o -name '*.css' \
    \) \
    -print0 | \
    xargs -0 \
    -I '{}' sh -c 'minify -o "{}" "{}"'

RUN CGO_ENABLED=1 GOOS=linux go build -ldflags="-s -w -linkmode 'external' -extldflags '-static'" -o ./bin/song-stitch cmd/*.go

FROM gcr.io/distroless/static-debian12:nonroot@sha256:e9ac71e2b8e279a8372741b7a0293afda17650d926900233ec3a7b2b7c22a246 AS build-release-stage

WORKDIR /app 

COPY --chown=nonroot:nonroot --from=builder /app/bin/song-stitch /app/song-stitch  
COPY --chown=nonroot:nonroot --from=builder /app/public /app/public  
COPY --chown=nonroot:nonroot assets/NotoSans-Bold.ttf assets/NotoSans-Regular.ttf /app/assets/   

ENTRYPOINT ["/app/song-stitch"] 
```